### PR TITLE
Edits based on offline discussions

### DIFF
--- a/core.md
+++ b/core.md
@@ -96,7 +96,7 @@ object with options provided as named fields.
 ##### Standard structs
 
 ```js
-var PointType = new StructType({x: float64, y: float64});
+const PointType = new StructType({x: float64, y: float64});
 ```
 
 This defines a new type definition `PointType` that consists of two
@@ -111,7 +111,7 @@ struct would:
 ##### Fixed-sized indexed structs
 
 ```js
-var LineType = new StructType(PointType, 2);
+const LineType = new StructType(PointType, 2);
 ```
 
 This defines a new type definition `LineType` that consists of two indexed
@@ -127,7 +127,7 @@ elements, each an instance of `PointType`. These will be laid out in memory cons
 An equivalent definition to this, that'd become unwieldy for large `length`s, would be:
 
 ```js
-var LineType = new StructType({0: PointType, 1: PointType});
+const LineType = new StructType({0: PointType, 1: PointType});
 ```
 
 ##### Nested structs
@@ -135,7 +135,7 @@ var LineType = new StructType({0: PointType, 1: PointType});
 Struct types can embed other struct types both as indexed elements as above and as named fields:
 
 ```js
-var LineType = new StructType({from: PointType, to: PointType});
+const LineType = new StructType({from: PointType, to: PointType});
 ```
 
 The result is a structure that contains two points embedded (again,
@@ -156,7 +156,7 @@ example, if you make a JavaScript object using an expression like the
 following:
 
 ```js
-var line = { from: { x: 3, y: 5 }, to: { x: 7, y: 8 } };
+let line = { from: { x: 3, y: 5 }, to: { x: 7, y: 8 } };
 ```
 
 you will create three objects, which means you have a memory
@@ -224,14 +224,14 @@ object". This object will be used to extract the initial values for
 each field:
 
 ```js
-var line1 = new LineType({from: {x: 1, y: 2},
+let line1 = new LineType({from: {x: 1, y: 2},
                           to: {x: 3, y: 4}});
 console.log(line1.from.x); // logs 1
 
-var line2 = new LineType(line1);
+let line2 = new LineType(line1);
 console.log(line2.from.x); // also logs 1
 
-var array = new PointType.array([{x: 1, y: 2}, {x: 3, y: 4}]);
+let array = new PointType.array([{x: 1, y: 2}, {x: 3, y: 4}]);
 console.log(array[0].x); // ALSO logs 1
 ```
 
@@ -240,13 +240,13 @@ object or another typed object. The only requirement is that it have
 fields of the appropriate type. Essentially, writing:
 
 ```js
-var line1 = new LineType(example);
+let line1 = new LineType(example);
 ```
 
 is exactly equivalent to writing:
 
 ```js
-var line1 = new LineType();
+let line1 = new LineType();
 line1.from.x = example.from.x;
 line1.from.y = example.from.y;
 line1.from.x = example.to.x;
@@ -259,7 +259,7 @@ Conceptually at least, every typed object is actually a *view* onto a
 backing buffer. So if you create a line like:
 
 ```js
-var line1 = new LineType({from: {x: 1, y: 2},
+let line1 = new LineType({from: {x: 1, y: 2},
                           to: {x: 3, y: 4}});
 ```
 
@@ -292,9 +292,9 @@ then the result is a new typed object pointer that points into the same
 backing buffer as before. Therefore, this fragment of code:
 
 ```js
-var line1 = new LineType({from: {x: 1, y: 2},
+let line1 = new LineType({from: {x: 1, y: 2},
                           to: {x: 3, y: 4}});
-var toPoint = line1.to;
+let toPoint = line1.to;
 ```
 
 yields the following result:
@@ -326,12 +326,12 @@ have an array of structs, then the result is a new typed object pointing into
 the same buffer, just as when accessing a struct field:
 
 ```js
-var ColorType = new StructType({r: uint8, g: uint8,
-                                b: uint8, a: uint8});
-var ColumnType = new StructType(ColorType, 1024);
-var ImageType = new StructType(ColumnType, 768);
+const ColorType = new StructType({r: uint8, g: uint8,
+                                  b: uint8, a: uint8});
+const ColumnType = new StructType(ColorType, 1024);
+const ImageType = new StructType(ColumnType, 768);
 
-var image = new ImageType();
+let image = new ImageType();
 image[22] // yields a typed object of type ColumnType
 image[22][44] // yields a typed object of type ColorType
 image[22][44].r // yields a number
@@ -344,7 +344,7 @@ The process is precisely the same as when providing an initial value
 for a typed object. This means that you can write things like:
 
 ```js
-var line = new LineType();
+let line = new LineType();
 line.to = {x: 22, y: 44};
 console.log(line.from.x); // prints 0
 console.log(line.to.x); // prints 22
@@ -376,10 +376,10 @@ field has struct type. Based on this, you might wonder what happens if you
 access the same field twice in a row:
 
 ```js
-var line = new LineType({from: {x: 1, y: 2},
+let line = new LineType({from: {x: 1, y: 2},
                          to: {x: 3, y: 4}});
-var toPoint1 = line.to;
-var toPoint2 = line.to;
+let toPoint1 = line.to;
+let toPoint2 = line.to;
 ```
 
 The answer is that each time you access the same field, you get back
@@ -423,8 +423,8 @@ typed view onto its contents. That can be achieved using the `view`
 method offered by struct and array type definitions:
 
 ```js
-var buffer = new ArrayBuffer(...);
-var line = LineType.view(buffer, offset);
+let buffer = new ArrayBuffer(...);
+let line = LineType.view(buffer, offset);
 ```
 
 You can also obtain information about the backing buffer from an existing
@@ -449,8 +449,8 @@ Sometimes, though, it's useful to allow accessing the underlying buffer. This ca
 ```js
 const TransparentPoint = new StructType({x: float64, y: float64}, {transparent: true});
 const Point = new StructType({x: float64, y: float64});
-var point = new TransparentPoint({x: 10, y: 100});
-var opaquePoint = Point.view(buffer(point), offset(point));
+let point = new TransparentPoint({x: 10, y: 100});
+let opaquePoint = Point.view(buffer(point), offset(point));
 
 buffer(opaquePoint); // yields undefined
 offset(opaquePoint); // yields undefined

--- a/core.md
+++ b/core.md
@@ -85,9 +85,12 @@ function StructType(structure, [options])
 function StructType(elementType, length, [options])
 ```
 
-The first overload defines struct types with the fields given in `structure`.
-The second is a shortcut for defining struct types with indexed elements of a
-certain type: each entry is an instance of the struct type `elementType`, and
+The first overload defines struct types with the fields given in `structure`. The
+`structure` argument must recursively consist of fields whose values are type
+definitions: either primitive or struct type definitions.
+
+The second overload is a shortcut for defining struct types with indexed elements
+of a certain type: each entry is an instance of the struct type `elementType`, and
 the length is determined by `length`.
 
 In both cases, the optional `options` parameter, if provided, must be an

--- a/core.md
+++ b/core.md
@@ -4,17 +4,20 @@
 
 The explainer proceeds as follows:
 
-- Explain type definitions:
-  - primitives
-  - structs
-  - arrays
-- Explain typed objects:
-  - instantiating structs and arrays
-  - backing buffers
-  - accessing fields of struct or array type
-  - prototypes
-- Interacting with array buffers
-  - Transparency and opacity
+- [Explain type definitions](#type-definition-objects):
+  - [primitives](#primitive-type-definitions)
+  - [structs](#struct-type-definitions)
+  - [arrays](#array-type-definitions)
+- [Explain typed objects](#typed-objects-instantiating-struct-types):
+  - [instantiating structs and arrays](#typed-objects-instantiating-struct-types)
+  - [backing buffers](#backing-buffers)
+  - [accessing fields of struct or array type](#reading-fields-and-elements)
+    - [reading fields](#reading-fields-and-elements)
+    - [assigning fields](#assigning-fields)
+  - [canonicalization and equality](#canonicalization-of-typed-objects--equality)
+  - [prototypes](#prototypes)
+- [Interacting with array buffers](#interacting-with-array-buffers)
+  - [Transparency and opacity](#opacity)
 
 ## Type definition objects
 
@@ -411,11 +414,11 @@ return `undefined` for the `buffer`, `offset`, and `length` funtions.
 
     var point = new Point();
     var point1 = opaque(point);
-    
+
     buffer(point)  // yields a buffer
     offset(point)  // yields 0
     length(point)  // yields 16
-    
+
     buffer(point1) // yields undefined
     offset(point1) // yields undefined
     length(point1) // yields undefined
@@ -433,4 +436,3 @@ opaque type definition throws an exception.
 *NOTE:*
 [Issue #2](https://github.com/nikomatsakis/typed-objects-explainer/issues/2)
 proposes to change some details of this section.
-

--- a/core.md
+++ b/core.md
@@ -49,6 +49,8 @@ coerce the value into the specified size:
 int8(128)   // returns 127
 int8("128") // returns 127
 int8(2.2)   // returns 2
+int8({valueOf() {return "2.2"}}) // returns 2
+int8({}) // returns 0, because Number({}) results in NaN, which is replaced with the default value 0.
 ```
 
 If you're familiar with C, these coercions are basically equivalent to
@@ -67,7 +69,7 @@ Finally, in the case of `any`, the coercion is a no-op, because any
 kind of value is acceptable:
 
 ```js
-any(x) == x
+any(x) === x
 ```
 
 In this base spec, the set of primitive type definitions cannot be

--- a/core.md
+++ b/core.md
@@ -411,13 +411,32 @@ placed into a weakmap.
 
 ## Prototypes
 
-FIXME
+All typed objects have an accompanying `prototype`. The `[[Prototype]]` of new instances of a type is set to that `prototype`. For struct types, the `prototype`'s own `[[Prototype]]` is immutably set to `StructType.prototype`. The `[[Prototype]]` of arrays of a struct type `Point`, instantiated using `new Point.array()`, is set to `Point.array.prototype`. That object's own `[[Prototype]]` is set to `StructType.array.prototype`.
+
+In code:
+
+```js
+const Point({x: float64, y: float64});
+const Line({start: Point, end: Point});
+let point = new Point();
+let points1 = new Point.array(2);
+let points2 = new Point.array(5);
+let line = new Line();
+// These all yield `true`:
+point.__proto__ === Point.prototype;
+points1.__proto__ === Point.array.prototype;
+points2.__proto__ === points1.__proto__;
+Point.prototype.__proto__ === StructType.prototype;
+Point.array.prototype.__proto__ === StructType.array.prototype;
+line.__proto__ === Line.prototype;
+line.start.__proto__ === Point.prototype;
+```
 
 # Interacting with array buffers
 
 In all the examples we have shown thus far, we have used the `new`
-constructor to create instances of struct or array type definitions,
-which in turn implies that we create a new backing buffer. Sometimes,
+constructor to create instances of struct type definitions or their accompanying
+array types, which in turn implies that we create a new backing buffer. Sometimes,
 though, it can be useful to take an existing array buffer and create a
 typed view onto its contents. That can be achieved using the `view`
 method offered by struct and array type definitions:


### PR DESCRIPTION
These changes are the result of an extended discussion between me and @nmatsakis.

The most important bits are
- the removal of array types in favor of StructType constructor overloads and `.array` constructors accompanying all struct types.
- changing from transparent- to opaque-by-default for struct types.
- documenting prototype chains.
